### PR TITLE
feat: support active server push notification

### DIFF
--- a/app/components/MessageDisplay.tsx
+++ b/app/components/MessageDisplay.tsx
@@ -36,7 +36,7 @@ export default function MessageDisplay({
   return (
     <div
       className={clsx(
-        "text-neutral-400 dark:text-neutral-500 pt-4 text-center max-w-xl text-balance min-h-28 space-y-4 transition-all duration-500",
+        "text-neutral-400 dark:text-neutral-500 pt-4 text-center max-w-lg text-balance min-h-28 space-y-4 transition-all duration-500",
         {
           "scale-95 -translate-y-2 opacity-40 blur-sm": isSettingsOpen
         }

--- a/app/components/MessageDisplay.tsx
+++ b/app/components/MessageDisplay.tsx
@@ -1,6 +1,6 @@
-import Link from "./Link";
 import clsx from "clsx";
-import { useTranslations, useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
+import Link from "./Link";
 
 type Message = {
   role: "user" | "assistant";
@@ -36,7 +36,7 @@ export default function MessageDisplay({
   return (
     <div
       className={clsx(
-        "text-neutral-400 dark:text-neutral-600 pt-4 text-center max-w-xl text-balance min-h-28 space-y-4 transition-all duration-500",
+        "text-neutral-400 dark:text-neutral-500 pt-4 text-center max-w-xl text-balance min-h-28 space-y-4 transition-all duration-500",
         {
           "scale-95 -translate-y-2 opacity-40 blur-sm": isSettingsOpen
         }

--- a/app/components/NotificationStatus.tsx
+++ b/app/components/NotificationStatus.tsx
@@ -1,0 +1,38 @@
+import { ConnectionStatus } from "@/lib/types/pusher";
+
+interface NotificationStatusProps {
+  status: ConnectionStatus;
+  statusText: string;
+}
+
+export default function NotificationStatus({
+  status,
+  statusText
+}: NotificationStatusProps) {
+  const getStatusColor = (status: ConnectionStatus) => {
+    switch (status) {
+      case "connected":
+        return "bg-green-500";
+      case "connecting":
+        return "bg-yellow-500 animate-pulse";
+      case "disconnected":
+        return "bg-gray-500";
+      case "error":
+        return "bg-red-500";
+      default:
+        return "bg-gray-500";
+    }
+  };
+
+  return (
+    <div className="flex items-center space-x-2 text-xs">
+      <div
+        className={`w-2 h-2 rounded-full ${getStatusColor(status)}`}
+        id="eventStatusIndicator"
+      />
+      <span className="text-gray-400" id="eventStatusText">
+        {statusText}
+      </span>
+    </div>
+  );
+}

--- a/app/lib/hooks/usePusher.ts
+++ b/app/lib/hooks/usePusher.ts
@@ -1,0 +1,226 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import Pusher from "pusher-js";
+import { agentCoreConfig } from "@/config";
+import type {
+  PusherConfig,
+  ChannelInfo,
+  ConnectionStatus,
+  PusherEventHandlers
+} from "@/lib/types/pusher";
+
+interface UsePusherProps {
+  isAuthenticated: boolean;
+  getToken: () => string | null;
+  eventHandlers: PusherEventHandlers;
+}
+
+export function usePusher({
+  isAuthenticated,
+  getToken,
+  eventHandlers
+}: UsePusherProps) {
+  const [status, setStatus] = useState<ConnectionStatus>("disconnected");
+  const [statusText, setStatusText] = useState("Disconnected");
+
+  const pusherRef = useRef<any>(null);
+  const userChannelRef = useRef<any>(null);
+  const connectionRetriesRef = useRef(0);
+  const isInitializingRef = useRef(false);
+
+  const MAX_RETRIES = 5;
+  const RETRY_DELAY = 2000;
+
+  const updateStatus = useCallback(
+    (newStatus: ConnectionStatus, text: string) => {
+      setStatus(newStatus);
+      setStatusText(text);
+    },
+    []
+  );
+
+  const handlePusherError = useCallback(() => {
+    if (connectionRetriesRef.current < MAX_RETRIES) {
+      connectionRetriesRef.current++;
+      console.log(
+        `Retrying Pusher connection (${connectionRetriesRef.current}/${MAX_RETRIES})...`
+      );
+      setTimeout(() => {
+        disconnectPusher();
+        if (isAuthenticated) {
+          initializePusher();
+        }
+      }, RETRY_DELAY * connectionRetriesRef.current);
+    } else {
+      console.error("Max Pusher connection retries reached");
+      updateStatus("disconnected", "Connection failed");
+    }
+  }, [isAuthenticated]);
+
+  const disconnectPusher = useCallback(() => {
+    if (userChannelRef.current) {
+      userChannelRef.current.unbind_all();
+      if (pusherRef.current) {
+        pusherRef.current.unsubscribe(userChannelRef.current.name);
+      }
+      userChannelRef.current = null;
+    }
+
+    if (pusherRef.current) {
+      pusherRef.current.disconnect();
+      pusherRef.current = null;
+    }
+
+    updateStatus("disconnected", "Disconnected");
+    isInitializingRef.current = false;
+  }, [updateStatus]);
+
+  const apiCall = useCallback(
+    async (endpoint: string) => {
+      const token = getToken();
+      const fullUrl = `${agentCoreConfig.baseURL}${endpoint}`;
+      const response = await fetch(fullUrl, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json"
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`API call failed: ${response.status}`);
+      }
+
+      return response;
+    },
+    [getToken]
+  );
+
+  const initializePusher = useCallback(async () => {
+    if (!isAuthenticated || pusherRef.current || isInitializingRef.current) {
+      return;
+    }
+
+    isInitializingRef.current = true;
+    console.log("Initializing Pusher connection...");
+    updateStatus("connecting", "Connecting...");
+
+    try {
+      // Get Pusher configuration from backend
+      const configResponse = await apiCall("/events/config");
+      const config: PusherConfig = await configResponse.json();
+      console.log("Pusher config received:", {
+        key: config.key,
+        cluster: config.cluster
+      });
+
+      // Initialize Pusher
+      pusherRef.current = new Pusher(config.key, {
+        cluster: config.cluster,
+        authEndpoint: `${agentCoreConfig.baseURL}/events/auth`,
+        auth: {
+          headers: {
+            "Content-Type": "application/json"
+          }
+        }
+      });
+
+      // Get user's channel information
+      const channelResponse = await apiCall("/events/channel");
+      const channelInfo: ChannelInfo = await channelResponse.json();
+      console.log("Channel info received:", channelInfo);
+
+      // Subscribe to user's private channel
+      userChannelRef.current = pusherRef.current.subscribe(channelInfo.channel);
+
+      // Handle connection events
+      pusherRef.current.connection.bind("connected", () => {
+        console.log("Pusher connected");
+        updateStatus("connected", "Connected");
+        connectionRetriesRef.current = 0;
+        isInitializingRef.current = false;
+      });
+
+      pusherRef.current.connection.bind("disconnected", () => {
+        console.log("Pusher disconnected");
+        updateStatus("disconnected", "Disconnected");
+        isInitializingRef.current = false;
+      });
+
+      pusherRef.current.connection.bind("error", (error: any) => {
+        console.error("Pusher connection error:", error);
+        updateStatus("disconnected", "Connection error");
+        isInitializingRef.current = false;
+        handlePusherError();
+      });
+
+      // Handle channel subscription events
+      userChannelRef.current.bind("pusher:subscription_succeeded", () => {
+        console.log("Successfully subscribed to user channel");
+        updateStatus("connected", "Connected");
+      });
+
+      userChannelRef.current.bind("pusher:subscription_error", (error: any) => {
+        console.error("Channel subscription error:", error);
+        updateStatus("disconnected", "Subscription failed");
+        isInitializingRef.current = false;
+        handlePusherError();
+      });
+
+      // Bind to specific event types
+      userChannelRef.current.bind(
+        "gmail_important_email",
+        eventHandlers.onEmailNotification
+      );
+      userChannelRef.current.bind(
+        "calendar_upcoming_event",
+        eventHandlers.onCalendarUpcoming
+      );
+      userChannelRef.current.bind(
+        "calendar_new_event",
+        eventHandlers.onCalendarNew
+      );
+      userChannelRef.current.bind(
+        "system_notification",
+        eventHandlers.onSystemNotification
+      );
+      userChannelRef.current.bind("chat_message", eventHandlers.onChatMessage);
+    } catch (error) {
+      console.error("Failed to initialize Pusher:", error);
+      updateStatus("disconnected", "Failed to connect");
+      isInitializingRef.current = false;
+      handlePusherError();
+    }
+  }, [
+    isAuthenticated,
+    getToken,
+    eventHandlers,
+    updateStatus,
+    handlePusherError,
+    apiCall
+  ]);
+
+  // Initialize Pusher when user is authenticated
+  useEffect(() => {
+    if (isAuthenticated && !pusherRef.current) {
+      initializePusher();
+    } else if (!isAuthenticated && pusherRef.current) {
+      disconnectPusher();
+      connectionRetriesRef.current = 0;
+    }
+  }, [isAuthenticated, initializePusher, disconnectPusher]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      disconnectPusher();
+      connectionRetriesRef.current = 0;
+    };
+  }, [disconnectPusher]);
+
+  return {
+    status,
+    statusText,
+    isConnected: status === "connected",
+    disconnect: disconnectPusher,
+    reconnect: initializePusher
+  };
+}

--- a/app/lib/hooks/useVADManager.ts
+++ b/app/lib/hooks/useVADManager.ts
@@ -297,7 +297,13 @@ export function useVADManager(
     onSpeechStart,
     onSpeechEnd,
     onVADMisfire: () => {
-      console.log("VAD: Misfire detected");
+      console.log("VAD: Misfire detected, resetting Orb state");
+      setVADState(prev => ({
+        ...prev,
+        actualUserSpeaking: false,
+        userSpeaking: false,
+        shouldShowOrb: false
+      }));
     },
     positiveSpeechThreshold: config.positiveSpeechThreshold || 0.7,
     minSpeechFrames: config.minSpeechFrames || 6,

--- a/app/lib/hooks/useVADManager.ts
+++ b/app/lib/hooks/useVADManager.ts
@@ -308,7 +308,7 @@ export function useVADManager(
     positiveSpeechThreshold: config.positiveSpeechThreshold || 0.8,
     minSpeechFrames: config.minSpeechFrames || 10,
     negativeSpeechThreshold: 0.6, // Increased from 0.5 for cleaner cutoffs
-    redemptionFrames: 3, // Reduced from 4 for shorter speech tails
+    redemptionFrames: 4, // Reduced from 4 for shorter speech tails
     preSpeechPadFrames: 1,
     // frameSamples: 480, // Aligned with RNNoise frame size
     stream: audioStream

--- a/app/lib/hooks/useVADManager.ts
+++ b/app/lib/hooks/useVADManager.ts
@@ -305,8 +305,12 @@ export function useVADManager(
         shouldShowOrb: false
       }));
     },
-    positiveSpeechThreshold: config.positiveSpeechThreshold || 0.7,
-    minSpeechFrames: config.minSpeechFrames || 6,
+    positiveSpeechThreshold: config.positiveSpeechThreshold || 0.8,
+    minSpeechFrames: config.minSpeechFrames || 10,
+    negativeSpeechThreshold: 0.6, // Increased from 0.5 for cleaner cutoffs
+    redemptionFrames: 3, // Reduced from 4 for shorter speech tails
+    preSpeechPadFrames: 1,
+    // frameSamples: 480, // Aligned with RNNoise frame size
     stream: audioStream
   });
 

--- a/app/lib/types/pusher.ts
+++ b/app/lib/types/pusher.ts
@@ -1,0 +1,56 @@
+export interface PusherConfig {
+  key: string;
+  cluster: string;
+}
+
+export interface ChannelInfo {
+  channel: string;
+}
+
+export type ConnectionStatus =
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "error";
+
+export interface NotificationOptions {
+  type: "email" | "calendar" | "system" | "chat";
+  title: string;
+  content: string;
+  priority: "low" | "medium" | "high" | "urgent";
+  timestamp: Date;
+}
+
+export interface EmailNotificationData {
+  subject: string;
+  fromAddress: string;
+  priority: "low" | "medium" | "high" | "urgent";
+  timestamp: string;
+}
+
+export interface CalendarEventData {
+  title: string;
+  timeUntilStart?: number;
+  startTime?: string;
+  priority: "low" | "medium" | "high" | "urgent";
+  timestamp: string;
+}
+
+export interface SystemNotificationData {
+  title?: string;
+  message: string;
+  timestamp: string;
+}
+
+export interface ChatMessageData {
+  message: string;
+  timestamp: string;
+}
+
+export interface PusherEventHandlers {
+  onEmailNotification: (data: EmailNotificationData) => void;
+  onCalendarUpcoming: (data: CalendarEventData) => void;
+  onCalendarNew: (data: CalendarEventData) => void;
+  onSystemNotification: (data: SystemNotificationData) => void;
+  onChatMessage: (data: ChatMessageData) => void;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -718,10 +718,10 @@ export default function Home() {
   // VAD Manager setup
   const vadManager = useVADManager(
     {
-      positiveSpeechThreshold: 0.8,
-      minSpeechFrames: 10,
+      positiveSpeechThreshold: 0.7,
+      minSpeechFrames: 8,
       rmsEnergyThreshold: -40,
-      minSpeechDuration: 400,
+      minSpeechDuration: 1000,
       spectralCentroidThreshold: 900
     },
     {
@@ -789,7 +789,9 @@ export default function Home() {
       // Use the existing submit function with transcript object to leverage full SSE/audio pipeline
       console.log("Submitting transcript:", data.message);
       startTransition(() => {
-        console.log("Inside transition, calling submit with:", { transcript: data.message });
+        console.log("Inside transition, calling submit with:", {
+          transcript: data.message
+        });
         submit({ transcript: data.message });
       });
     },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -677,10 +677,9 @@ export default function Home() {
       // Stop audio playback immediately
       playerRef.current.stop();
 
-      // Reset streaming state immediately
+      // Reset streaming state but preserve message
       updateChatStateRef.current({
-        isStreaming: false,
-        message: ""
+        isStreaming: false
       });
     }
   }, []);
@@ -709,11 +708,11 @@ export default function Home() {
   // VAD Manager setup
   const vadManager = useVADManager(
     {
-      positiveSpeechThreshold: 0.7,
+      positiveSpeechThreshold: 0.6,
       minSpeechFrames: 6,
-      rmsEnergyThreshold: -35,
+      rmsEnergyThreshold: -40,
       minSpeechDuration: 400,
-      spectralCentroidThreshold: 1000
+      spectralCentroidThreshold: 900
     },
     {
       onSpeechStart,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next": "15.3.0",
     "next-intl": "^4.3.4",
     "onnxruntime-web": "^1.21.0",
+    "pusher-js": "^8.4.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "sonner": "^2.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       onnxruntime-web:
         specifier: ^1.21.0
         version: 1.22.0
+      pusher-js:
+        specifier: ^8.4.0
+        version: 8.4.0
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -2920,6 +2923,9 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
+  pusher-js@8.4.0:
+    resolution: {integrity: sha512-wp3HqIIUc1GRyu1XrP6m2dgyE9MoCsXVsWNlohj0rjSkLf+a0jLvEyVubdg58oMk7bhjBWnFClgp8jfAa6Ak4Q==}
+
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
@@ -3293,6 +3299,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -6738,6 +6747,10 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
+  pusher-js@8.4.0:
+    dependencies:
+      tweetnacl: 1.0.3
+
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
@@ -7166,6 +7179,8 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tweetnacl@1.0.3: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
This pull request introduces a Pusher integration for real-time notifications, including a new `NotificationStatus` component, a custom `usePusher` hook, and related type definitions. Additionally, it updates dependencies to include the `pusher-js` library. Below are the most important changes grouped by theme.

### Pusher Integration:

* **`usePusher` Hook**: Added a custom hook in `app/lib/hooks/usePusher.ts` to manage the Pusher connection, handle events, and update connection status. Includes functionality for retrying connections, subscribing to channels, and binding event handlers.
* **Type Definitions**: Defined types for Pusher configuration, connection status, notification data, and event handlers in `app/lib/types/pusher.ts`. These types are used across the integration for better type safety.

### UI Enhancements:

* **`NotificationStatus` Component**: Created a new component in `app/components/NotificationStatus.tsx` to display the current Pusher connection status with a color-coded indicator and status text.
* **Integration into `Home` Page**: Added the `NotificationStatus` component and integrated the `usePusher` hook into the `Home` page (`app/page.tsx`) to handle and display real-time notifications. Includes event handlers for email, calendar, system, and chat notifications. [[1]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R6-R21) [[2]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R732-R795) [[3]](diffhunk://#diff-6efdf509a785a0658b2e31a8c33d298de14321d9672179370e99cc76241c1eb0R893-R902)

### Dependency Updates:

* **`pusher-js` Library**: Added `pusher-js` version `8.4.0` to `package.json` and updated the `pnpm-lock.yaml` file to include the library and its dependency `tweetnacl`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R29) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR41-R43) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2926-R2928) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3303-R3305) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR6750-R6753) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7183-R7184)