### PR TITLE
fix: prevent duplicate calls

### DIFF
--- a/app/lib/auth.ts
+++ b/app/lib/auth.ts
@@ -191,6 +191,13 @@ export const authService = {
       }
 
       if (code) {
+        // Clean up URL immediately to prevent duplicate calls
+        window.history.replaceState(
+          {},
+          document.title,
+          window.location.pathname
+        );
+
         const redirectUri = `${window.location.origin}${window.location.pathname}`;
         const userData = await apiCall("/auth/oauth/token", {
           code,
@@ -207,12 +214,6 @@ export const authService = {
           token: userData.access_token
         });
 
-        // Clean up URL
-        window.history.replaceState(
-          {},
-          document.title,
-          window.location.pathname
-        );
         return true;
       }
 


### PR DESCRIPTION
This pull request improves the `authService` in `app/lib/auth.ts` by ensuring the URL is cleaned up earlier during the OAuth flow to prevent duplicate calls. The change moves the `window.history.replaceState` logic to execute immediately after detecting the `code` parameter.

### Key Changes:

* **OAuth URL Cleanup Timing:**
  - Moved the `window.history.replaceState` call to execute immediately after detecting the `code` parameter, ensuring the URL is cleaned up earlier in the process. This prevents potential duplicate calls caused by the presence of the `code` in the URL. (`[[1]](diffhunk://#diff-00edcb7cb402610ed7c96acfc98b4f1847866ecad3f56816d26bc73f339d2469R194-R200)`, `[[2]](diffhunk://#diff-00edcb7cb402610ed7c96acfc98b4f1847866ecad3f56816d26bc73f339d2469L210-L215)`)