### PR TITLE
Fix/notification

### DIFF
--- a/app/api/route.ts
+++ b/app/api/route.ts
@@ -357,8 +357,6 @@ export async function POST(request: Request) {
 
           // Handle text input using chatStream
           if (typeof data.input === "string") {
-            console.debug("Text SSE: Processing text input:", data.input);
-
             // Use AgentCore chat streaming for text-only input
             const chatStream = agentCore.chatStream(
               data.input,
@@ -367,23 +365,11 @@ export async function POST(request: Request) {
               abortController.signal
             );
 
-            console.debug("Text SSE: chatStream created successfully");
-
             // Process chat stream events
             let eventCount = 0;
             for await (const event of chatStream) {
               eventCount++;
-
-              console.debug(
-                `Text SSE: Received chunk #${eventCount}:`,
-                event.type,
-                event
-              );
-
               if (abortController.signal.aborted || isControllerClosed) {
-                console.debug(
-                  "Text SSE: Text streaming interrupted - abort signal or controller closed"
-                );
                 break;
               }
 
@@ -391,9 +377,6 @@ export async function POST(request: Request) {
               const sseEvent = formatEventAsSSE(event);
 
               if (sseEvent && !safeEnqueue(encoder.encode(sseEvent))) {
-                console.debug(
-                  "Text SSE: Text streaming stopped - failed to enqueue"
-                );
                 break;
               }
 
@@ -402,9 +385,7 @@ export async function POST(request: Request) {
                 break;
               }
             }
-            console.debug(
-              `Text SSE: Text streaming completed after ${eventCount} chunks`
-            );
+
             if (eventCount === 0) {
               console.error(
                 "Text SSE: No chunks received from agentCore.chatStream!"
@@ -432,16 +413,6 @@ export async function POST(request: Request) {
           }
 
           // Use AgentCore voice streaming
-          console.debug(
-            "Voice SSE: Creating voiceStream with settings:",
-            settings
-          );
-          console.debug(
-            "Voice SSE: Input file size:",
-            data.input.size,
-            "bytes"
-          );
-
           const voiceStream = agentCore.voiceStream(
             data.input,
             settings.ttsEngine as "cartesia" | "elevenlabs" | "cartesiachinese",
@@ -455,24 +426,11 @@ export async function POST(request: Request) {
             }
           );
 
-          console.debug("Voice SSE: voiceStream created successfully");
-
-          // Process voice stream events
-          console.debug("Voice SSE: Starting to iterate over voiceStream");
-
           let eventCount = 0;
           for await (const event of voiceStream) {
             eventCount++;
-            console.debug(
-              `Voice SSE: Received event #${eventCount}:`,
-              event.type,
-              event
-            );
 
             if (abortController.signal.aborted || isControllerClosed) {
-              console.debug(
-                "Voice SSE: Voice streaming interrupted - abort signal or controller closed"
-              );
               break;
             }
 
@@ -480,9 +438,6 @@ export async function POST(request: Request) {
             const sseEvent = formatEventAsSSE(event);
 
             if (sseEvent && !safeEnqueue(encoder.encode(sseEvent))) {
-              console.debug(
-                "Voice SSE: Voice streaming stopped - failed to enqueue"
-              );
               break;
             }
 
@@ -492,9 +447,6 @@ export async function POST(request: Request) {
             }
           }
 
-          console.debug(
-            `Voice SSE: Voice streaming completed after ${eventCount} events`
-          );
           if (eventCount === 0) {
             console.error(
               "Voice SSE: No events received from agentCore.voiceStream!"

--- a/app/hooks/__tests__/useNotificationHandlers.test.ts
+++ b/app/hooks/__tests__/useNotificationHandlers.test.ts
@@ -383,16 +383,16 @@ describe("useNotificationHandlers", () => {
         });
       });
 
-      // Advance timers to test the 3-second display duration
+      // Message should remain displayed (no auto-clearing)
       act(() => {
         jest.advanceTimersByTime(3000);
       });
 
-      await waitFor(() => {
-        expect(mockUpdateChatState).toHaveBeenCalledWith({
-          message: ""
-        });
+      // Should still show the message (no clearing)
+      expect(mockUpdateChatState).toHaveBeenCalledWith({
+        message: mockChatData.message
       });
+      expect(mockUpdateChatState).toHaveBeenCalledTimes(1);
     });
 
     it("should reject chat message when not authenticated", () => {
@@ -571,12 +571,12 @@ describe("useNotificationHandlers", () => {
 
       // Advance timers to complete processing
       act(() => {
-        jest.advanceTimersByTime(3000); // Complete 3s display time
+        jest.advanceTimersByTime(3000); // Wait for processing
       });
 
-      // Should have cleared the message
-      await waitFor(() => {
-        expect(mockUpdateChatState).toHaveBeenCalledWith({ message: "" });
+      // Should have displayed the message (no clearing)
+      expect(mockUpdateChatState).toHaveBeenCalledWith({ 
+        message: mockChatData.message 
       });
 
       // Try to process again - should not process anything since queue is empty
@@ -584,8 +584,8 @@ describe("useNotificationHandlers", () => {
         await result.current!.processMessageQueue();
       });
 
-      // Should have been called exactly 2 times: display + clear
-      expect(mockUpdateChatState).toHaveBeenCalledTimes(2);
+      // Should have been called exactly 1 time: display only (no clearing)
+      expect(mockUpdateChatState).toHaveBeenCalledTimes(1);
     });
 
     it("should wait between processing messages", async () => {
@@ -829,16 +829,14 @@ describe("useNotificationHandlers", () => {
         });
       });
 
-      // Advance time to test clearing
+      // Advance time for any processing
       act(() => {
         jest.advanceTimersByTime(3000);
       });
 
-      // Should clear the message
-      await waitFor(() => {
-        expect(localMockUpdateChatState).toHaveBeenCalledWith({
-          message: ""
-        });
+      // Should display the message (no clearing)
+      expect(localMockUpdateChatState).toHaveBeenCalledWith({
+        message: mockChatData.message
       });
     });
 
@@ -918,14 +916,13 @@ describe("useNotificationHandlers", () => {
         jest.advanceTimersByTime(3000);
       });
 
-      await waitFor(() => {
-        expect(mockUpdateChatState).toHaveBeenCalledWith({
-          message: ""
-        });
+      // Should display the message (no clearing)
+      expect(mockUpdateChatState).toHaveBeenCalledWith({
+        message: mockChatData.message
       });
 
-      // Verify queue is processed (display + clear = 2 calls)
-      expect(mockUpdateChatState).toHaveBeenCalledTimes(2);
+      // Verify queue is processed (display only = 1 call)
+      expect(mockUpdateChatState).toHaveBeenCalledTimes(1);
     });
 
     it("should handle edge cases in message processing", async () => {

--- a/app/hooks/__tests__/useStreamingProcessor.test.ts
+++ b/app/hooks/__tests__/useStreamingProcessor.test.ts
@@ -90,7 +90,7 @@ describe("useStreamingProcessor", () => {
         onError,
         expect.any(Number), // submittedAt timestamp
         undefined, // onTranscript callback
-        undefined  // onStatus callback
+        undefined // onStatus callback
       );
 
       expect(mockProcessor.processStream).toHaveBeenCalledWith(mockResponse);
@@ -216,7 +216,9 @@ describe("useStreamingProcessor", () => {
         );
       });
 
-      expect(callbacks.onError).toHaveBeenCalledWith(new Error("STREAM_ABORTED"));
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        new Error("STREAM_ABORTED")
+      );
 
       consoleSpy.mockRestore();
     });
@@ -250,7 +252,9 @@ describe("useStreamingProcessor", () => {
         );
       });
 
-      expect(callbacks.onError).toHaveBeenCalledWith(new Error("NETWORK_ERROR"));
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        new Error("NETWORK_ERROR")
+      );
 
       consoleSpy.mockRestore();
     });
@@ -284,7 +288,9 @@ describe("useStreamingProcessor", () => {
         );
       });
 
-      expect(callbacks.onError).toHaveBeenCalledWith(new Error("STREAM_TIMEOUT"));
+      expect(callbacks.onError).toHaveBeenCalledWith(
+        new Error("STREAM_TIMEOUT")
+      );
 
       consoleSpy.mockRestore();
     });
@@ -396,7 +402,7 @@ describe("useStreamingProcessor", () => {
         callbacks.onError,
         expect.any(Number), // submittedAt timestamp
         undefined, // onTranscript callback
-        undefined  // onStatus callback
+        undefined // onStatus callback
       );
 
       const submittedAt = (MockedSSEProcessor as jest.Mock).mock.calls[0][4];
@@ -664,7 +670,9 @@ describe("useStreamingProcessor", () => {
 
       const mockState = { accumulatedText: "test", isProcessing: true };
       mockProcessor.getState.mockReturnValue(mockState);
-      mockProcessor.processStream.mockImplementation(() => new Promise(() => {})); // Never resolves
+      mockProcessor.processStream.mockImplementation(
+        () => new Promise(() => {})
+      ); // Never resolves
 
       const { result } = renderHook(() => useStreamingProcessor());
 
@@ -706,7 +714,9 @@ describe("useStreamingProcessor", () => {
       };
 
       mockProcessor.isProcessing.mockReturnValue(true);
-      mockProcessor.processStream.mockImplementation(() => new Promise(() => {})); // Never resolves
+      mockProcessor.processStream.mockImplementation(
+        () => new Promise(() => {})
+      ); // Never resolves
 
       const { result } = renderHook(() => useStreamingProcessor());
 

--- a/app/hooks/__tests__/useVoiceChat.test.ts
+++ b/app/hooks/__tests__/useVoiceChat.test.ts
@@ -45,7 +45,6 @@ const mockRequestManager = {
   isProcessing: false
 };
 
-
 const mockPlayer = {
   playAudioChunk: jest.fn(),
   stop: jest.fn(),
@@ -63,7 +62,6 @@ const mockVoiceChatService = {
 jest.mock("@/hooks/useRequestManager", () => ({
   useRequestManager: jest.fn(() => mockRequestManager)
 }));
-
 
 jest.mock("@/lib/hooks/useAudioPlayer", () => ({
   useAudioPlayer: jest.fn(() => mockPlayer)
@@ -104,15 +102,15 @@ describe("useVoiceChat", () => {
         return Promise.resolve({ done: true, value: undefined });
       })
     };
-    
+
     const mockResponse = new Response(null, { status: 200 });
-    Object.defineProperty(mockResponse, 'body', {
+    Object.defineProperty(mockResponse, "body", {
       value: {
         getReader: () => mockReader
       },
       writable: false
     });
-    
+
     return mockResponse;
   };
 
@@ -121,7 +119,7 @@ describe("useVoiceChat", () => {
     mockVoiceChatService.translateError.mockImplementation(
       (msg: string) => msg
     );
-    
+
     // Reset player mock
     mockPlayer.initAudioPlayer.mockClear();
     mockPlayer.playAudioChunk.mockClear();
@@ -179,7 +177,7 @@ describe("useVoiceChat", () => {
         'event: text\ndata: {"data": "Hi there!"}\n\n',
         'event: complete\ndata: {"fullText": "Hi there!"}\n\n'
       ];
-      
+
       const mockSSEResponse = createSSEMockResponse(sseEvents);
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse);
 
@@ -203,22 +201,25 @@ describe("useVoiceChat", () => {
 
       // Should initialize audio player
       expect(mockPlayer.initAudioPlayer).toHaveBeenCalled();
-      
+
       // Wait for streaming to complete
-      await waitFor(() => {
-        expect(result.current.messages).toHaveLength(2);
-      }, { timeout: 5000 });
+      await waitFor(
+        () => {
+          expect(result.current.messages).toHaveLength(2);
+        },
+        { timeout: 5000 }
+      );
     });
 
     it("should handle blob input submission with SSE streaming", async () => {
       const mockBlob = new Blob(["audio data"], { type: "audio/webm" });
-      
+
       const sseEvents = [
         'event: transcript\ndata: {"data": "Transcribed text"}\n\n',
         'event: text\ndata: {"data": "Response"}\n\n',
         'event: complete\ndata: {"fullText": "Response"}\n\n'
       ];
-      
+
       const mockSSEResponse = createSSEMockResponse(sseEvents);
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse);
 
@@ -239,21 +240,24 @@ describe("useVoiceChat", () => {
           expect.any(Object)
         );
       });
-      
-      await waitFor(() => {
-        expect(result.current.messages).toHaveLength(2);
-      }, { timeout: 5000 });
+
+      await waitFor(
+        () => {
+          expect(result.current.messages).toHaveLength(2);
+        },
+        { timeout: 5000 }
+      );
     });
 
     it("should handle transcript object submission with SSE streaming", async () => {
       const mockTranscript = { transcript: "Hello from transcript" };
-      
+
       const sseEvents = [
         'event: transcript\ndata: {"data": "Hello from transcript"}\n\n',
         'event: text\ndata: {"data": "Response"}\n\n',
         'event: complete\ndata: {"fullText": "Response"}\n\n'
       ];
-      
+
       const mockSSEResponse = createSSEMockResponse(sseEvents);
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse);
 
@@ -274,10 +278,13 @@ describe("useVoiceChat", () => {
           expect.any(Object)
         );
       });
-      
-      await waitFor(() => {
-        expect(result.current.messages).toHaveLength(2);
-      }, { timeout: 5000 });
+
+      await waitFor(
+        () => {
+          expect(result.current.messages).toHaveLength(2);
+        },
+        { timeout: 5000 }
+      );
     });
   });
 
@@ -287,10 +294,10 @@ describe("useVoiceChat", () => {
         'event: transcript\ndata: {"data": "Hello"}\n\n',
         'event: text\ndata: {"data": "Partial "}\n\n',
         'event: text\ndata: {"data": "response"}\n\n',
-        'event: audio\ndata: {"data": "' + btoa('audiodata') + '"}\n\n',
+        'event: audio\ndata: {"data": "' + btoa("audiodata") + '"}\n\n',
         'event: complete\ndata: {"fullText": "Partial response"}\n\n'
       ];
-      
+
       const mockSSEResponse = createSSEMockResponse(sseEvents);
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse);
 
@@ -304,13 +311,16 @@ describe("useVoiceChat", () => {
 
       // Should initialize audio player
       expect(mockPlayer.initAudioPlayer).toHaveBeenCalled();
-      
+
       // Wait for SSE stream processing to complete
-      await waitFor(() => {
-        expect(result.current.messages).toHaveLength(2);
-        expect(result.current.messages[1].content).toBe("Partial response");
-      }, { timeout: 8000 });
-      
+      await waitFor(
+        () => {
+          expect(result.current.messages).toHaveLength(2);
+          expect(result.current.messages[1].content).toBe("Partial response");
+        },
+        { timeout: 8000 }
+      );
+
       // Audio should be played
       expect(mockPlayer.playAudioChunk).toHaveBeenCalled();
     });
@@ -322,7 +332,7 @@ describe("useVoiceChat", () => {
         'event: text\ndata: {"data": "Response text"}\n\n',
         'event: complete\ndata: {"fullText": "Response text"}\n\n'
       ];
-      
+
       const mockSSEResponse = createSSEMockResponse(sseEvents);
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse);
 
@@ -334,30 +344,38 @@ describe("useVoiceChat", () => {
         });
       });
 
-      await waitFor(() => {
-        expect(result.current.messages).toHaveLength(2);
-        expect(result.current.messages[1].content).toBe("Response text");
-      }, { timeout: 8000 });
+      await waitFor(
+        () => {
+          expect(result.current.messages).toHaveLength(2);
+          expect(result.current.messages[1].content).toBe("Response text");
+        },
+        { timeout: 8000 }
+      );
     });
 
     it("should handle SSE stream errors", async () => {
       const mockSSEResponse = {
         body: {
           getReader: () => ({
-            read: jest.fn()
-              .mockResolvedValueOnce({ 
-                done: false, 
-                value: new TextEncoder().encode('event: transcript\ndata: {"data": "Hello"}\n\n')
+            read: jest
+              .fn()
+              .mockResolvedValueOnce({
+                done: false,
+                value: new TextEncoder().encode(
+                  'event: transcript\ndata: {"data": "Hello"}\n\n'
+                )
               })
-              .mockResolvedValueOnce({ 
-                done: false, 
-                value: new TextEncoder().encode('event: error\ndata: {"message": "Stream error occurred"}\n\n')
+              .mockResolvedValueOnce({
+                done: false,
+                value: new TextEncoder().encode(
+                  'event: error\ndata: {"message": "Stream error occurred"}\n\n'
+                )
               })
               .mockResolvedValueOnce({ done: true, value: undefined })
           })
         }
       };
-      
+
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse as any);
 
       const { result } = renderHook(() => useVoiceChat(mockProps));
@@ -369,9 +387,12 @@ describe("useVoiceChat", () => {
       });
 
       // Should handle the error gracefully
-      await waitFor(() => {
-        expect(result.current.chatState.isStreaming).toBe(false);
-      }, { timeout: 3000 });
+      await waitFor(
+        () => {
+          expect(result.current.chatState.isStreaming).toBe(false);
+        },
+        { timeout: 3000 }
+      );
     });
   });
 
@@ -459,12 +480,13 @@ describe("useVoiceChat", () => {
       const mockSSEResponse = {
         body: {
           getReader: () => ({
-            read: jest.fn()
+            read: jest
+              .fn()
               .mockRejectedValueOnce(new Error("Stream read error"))
           })
         }
       };
-      
+
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse as any);
 
       const { result } = renderHook(() => useVoiceChat(mockProps));
@@ -571,7 +593,7 @@ describe("useVoiceChat", () => {
         'event: text\ndata: {"data": "response"}\n\n',
         'event: complete\ndata: {"fullText": "Partial response"}\n\n'
       ];
-      
+
       const mockSSEResponse = createSSEMockResponse(sseEvents);
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse);
 
@@ -584,9 +606,12 @@ describe("useVoiceChat", () => {
       });
 
       // Wait for processing to complete
-      await waitFor(() => {
-        expect(result.current.messages).toHaveLength(2);
-      }, { timeout: 8000 });
+      await waitFor(
+        () => {
+          expect(result.current.messages).toHaveLength(2);
+        },
+        { timeout: 8000 }
+      );
 
       expect(result.current.messages[1].content).toBe("Partial response");
       expect(result.current.chatState.input).toBe("Hello");
@@ -606,10 +631,10 @@ describe("useVoiceChat", () => {
       const sseEvents = [
         'event: transcript\ndata: {"data": "Hello"}\n\n',
         'event: text\ndata: {"data": "Response"}\n\n',
-        'event: audio\ndata: {"data": "' + btoa('audio') + '"}\n\n',
+        'event: audio\ndata: {"data": "' + btoa("audio") + '"}\n\n',
         'event: complete\ndata: {"fullText": "Response"}\n\n'
       ];
-      
+
       const mockSSEResponse = createSSEMockResponse(sseEvents);
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse);
 
@@ -622,12 +647,15 @@ describe("useVoiceChat", () => {
       });
 
       // Wait for final completion and verify we went through the phases
-      await waitFor(() => {
-        expect(result.current.chatState.streamPhase).toBe("completed");
-        expect(result.current.chatState.isStreaming).toBe(false);
-        expect(result.current.messages).toHaveLength(2);
-      }, { timeout: 8000 });
-      
+      await waitFor(
+        () => {
+          expect(result.current.chatState.streamPhase).toBe("completed");
+          expect(result.current.chatState.isStreaming).toBe(false);
+          expect(result.current.messages).toHaveLength(2);
+        },
+        { timeout: 8000 }
+      );
+
       // Verify input was set during the process
       expect(result.current.chatState.input).toBe("Hello");
     });
@@ -638,7 +666,7 @@ describe("useVoiceChat", () => {
         'event: text\ndata: {"data": "Hi there!"}\n\n',
         'event: complete\ndata: {"fullText": "Hi there!"}\n\n'
       ];
-      
+
       const mockSSEResponse = createSSEMockResponse(sseEvents);
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse);
 
@@ -651,11 +679,14 @@ describe("useVoiceChat", () => {
       });
 
       // Wait for completion and state reset
-      await waitFor(() => {
-        expect(result.current.chatState.isStreaming).toBe(false);
-        expect(result.current.chatState.message).toBe("");
-        expect(result.current.chatState.streamPhase).toBe("completed");
-      }, { timeout: 8000 });
+      await waitFor(
+        () => {
+          expect(result.current.chatState.isStreaming).toBe(false);
+          expect(result.current.chatState.message).toBe("");
+          expect(result.current.chatState.streamPhase).toBe("completed");
+        },
+        { timeout: 8000 }
+      );
     });
   });
 
@@ -679,7 +710,7 @@ describe("useVoiceChat", () => {
         'event: text\ndata: {"data": "Response text"}\n\n'
         // No complete event - stream just ends
       ];
-      
+
       const mockSSEResponse = createSSEMockResponse(sseEvents);
       mockVoiceChatService.submitChat.mockResolvedValue(mockSSEResponse);
 
@@ -692,11 +723,14 @@ describe("useVoiceChat", () => {
       });
 
       // Should handle completion gracefully even without explicit complete event
-      await waitFor(() => {
-        expect(result.current.messages).toHaveLength(2);
-        expect(result.current.messages[1].content).toBe("Response text");
-        expect(result.current.chatState.isStreaming).toBe(false);
-      }, { timeout: 8000 });
+      await waitFor(
+        () => {
+          expect(result.current.messages).toHaveLength(2);
+          expect(result.current.messages[1].content).toBe("Response text");
+          expect(result.current.chatState.isStreaming).toBe(false);
+        },
+        { timeout: 8000 }
+      );
     });
   });
 });

--- a/app/hooks/useNotificationHandlers.ts
+++ b/app/hooks/useNotificationHandlers.ts
@@ -123,6 +123,13 @@ export function useNotificationHandlers({
     while (messageQueueRef.current.length > 0) {
       const data = messageQueueRef.current.shift()!;
 
+      addNotification({
+        type: "chat",
+        title: "Proactive Message",
+        message: data.message,
+        data
+      });
+
       // Display the proactive message directly in the chat interface
       if (updateChatState) {
         console.log("Displaying proactive message:", data.message);
@@ -130,11 +137,11 @@ export function useNotificationHandlers({
       }
 
       // Wait before processing next message to allow reading time
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise(resolve => setTimeout(resolve, 4000));
     }
 
     isProcessingRef.current = false;
-  }, [updateChatState]);
+  }, [addNotification, updateChatState]);
 
   const handleChatMessage = useCallback(
     (data: ChatMessageData) => {

--- a/app/hooks/useNotificationHandlers.ts
+++ b/app/hooks/useNotificationHandlers.ts
@@ -127,10 +127,6 @@ export function useNotificationHandlers({
       if (updateChatState) {
         console.log("Displaying proactive message:", data.message);
         updateChatState({ message: data.message });
-
-        // Show message for a few seconds, then clear it
-        await new Promise(resolve => setTimeout(resolve, 3000));
-        updateChatState({ message: "" });
       }
 
       // Wait before processing next message to allow reading time

--- a/app/lib/agentCore.ts
+++ b/app/lib/agentCore.ts
@@ -238,12 +238,7 @@ export class AgentCoreService {
         while (true) {
           const { done, value } = await reader.read();
           chunkCount++;
-          console.log(
-            `AgentCore: Read chunk #${chunkCount}, done: ${done}, valueLength: ${value?.length}`
-          );
-
           if (done) {
-            console.log(`AgentCore: Stream done after ${chunkCount} chunks`);
             if (timeoutId) {
               clearTimeout(timeoutId);
             }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -92,7 +92,7 @@ export default function Home() {
   const notificationHandlers = useNotificationHandlers({
     auth,
     addNotification,
-    submit: voiceChat.submit
+    updateChatState: voiceChat.updateChatState
   });
 
   // Initialize Agent Core service

--- a/app/utils/__tests__/sseProcessor.test.ts
+++ b/app/utils/__tests__/sseProcessor.test.ts
@@ -50,7 +50,7 @@ describe("SSEProcessor", () => {
       onError,
       Date.now(),
       undefined, // onTranscript callback
-      undefined  // onStatus callback
+      undefined // onStatus callback
     );
 
     // Mock atob for base64 decoding in this test (overrides global)


### PR DESCRIPTION
This pull request focuses on two main areas: improving the maintainability of the `POST` handler in `app/api/route.ts` by removing excessive debug logging, and updating the `useNotificationHandlers` test suite to replace the `submit` mock with `updateChatState`, aligning the tests with changes in functionality.

### Changes in `app/api/route.ts` (Debug Logging Removal):
* Removed all `console.debug` statements related to text and voice streaming, including logs for input processing, stream creation, event handling, and completion. This reduces noise in logs and improves maintainability. [[1]](diffhunk://#diff-7f36570f38c57e94863d9a40944b6f6d95de2f83cc13f07f6692ebb30e146f87L360-L361) [[2]](diffhunk://#diff-7f36570f38c57e94863d9a40944b6f6d95de2f83cc13f07f6692ebb30e146f87L370-L396) [[3]](diffhunk://#diff-7f36570f38c57e94863d9a40944b6f6d95de2f83cc13f07f6692ebb30e146f87L405-R388) [[4]](diffhunk://#diff-7f36570f38c57e94863d9a40944b6f6d95de2f83cc13f07f6692ebb30e146f87L435-L444) [[5]](diffhunk://#diff-7f36570f38c57e94863d9a40944b6f6d95de2f83cc13f07f6692ebb30e146f87L458-L485) [[6]](diffhunk://#diff-7f36570f38c57e94863d9a40944b6f6d95de2f83cc13f07f6692ebb30e146f87L495-L497)

### Changes in `useNotificationHandlers` Test Suite:
* Replaced the `mockSubmit` function with `mockUpdateChatState` in all test cases, ensuring the tests reflect the updated behavior of the `useNotificationHandlers` hook. [[1]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL33-R33) [[2]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL46-R46) [[3]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL56-R56)
* Updated assertions to verify calls to `mockUpdateChatState` instead of `mockSubmit`, ensuring proper handling of chat state updates in scenarios like message processing, queuing, and error handling. [[1]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL379-R395) [[2]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL416-R420) [[3]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL442-R466) [[4]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL483-R510) [[5]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL519-R524) [[6]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL539-R545) [[7]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL560-R588) [[8]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL602-R634) [[9]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL669-R699) [[10]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL716-R765)
* Adjusted test descriptions and logic to reflect the transition from `submit` to `updateChatState`, ensuring clarity and alignment with the new implementation. [[1]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL784-R806) [[2]](diffhunk://#diff-86174eb1100b9f23d8de270a54300e90f598787a9607ece5dd69f0dbbe0d426cL829-R855)